### PR TITLE
Remove invalid isbn from bib file

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -219,7 +219,6 @@
 	number       = 13,
 	pages        = {2788--97},
 	doi          = {10.1364/AO.37.002788},
-	isbn         = {0003-6935},
 	issn         = {0003-6935},
 	url          = {http://www.ncbi.nlm.nih.gov/pubmed/18273225},
 	pmid         = 18273225


### PR DESCRIPTION
Attempt to fix error when running the `recommend-accept` workflow in https://github.com/openjournals/joss-reviews/issues/9551#issuecomment-3858735177. The error
```
Element isbn: [facet 'minLength'] The value has a length of '9'; this underruns the allowed minimum length of '10'.
```
seems to be related to an invalid isbn, so trying to just remove an invalid isbn in the bib file. 